### PR TITLE
fix email link formatting

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -51,7 +51,7 @@ function on_generated(acc_data) {
 	
 	$("#acc_login").html(`Login: <strong>${acc_data.login}</strong>`)
 	$("#acc_pass").html(`Password: <strong>${acc_data.password}</strong>`)
-	$("#acc_email").html(`<a href="https://inboxkitten.com/inbox/${acc_data.email.split("@")[0]}/list">E-Mail address: ${acc_data.email}`)
+	$("#acc_email").html(`E-Mail address: <a href="https://inboxkitten.com/inbox/${acc_data.email.split("@")[0]}/list">${acc_data.email}</a>`)
 	
 	$("#generated_data").show("slow")
 	$("#generate_button").show("slow")


### PR DESCRIPTION
fixes the issue where the word "E-Mail address:" is rendered white along with a hyperlink to the email inbox, now only the email text has the link.